### PR TITLE
Custom pre and post prepare_command options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rspec', '~> 3.3.0'
+gem 'rspec', '~> 3.6.0'

--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -85,6 +85,8 @@ module Kitchen
         default_config :custom_pre_play_command, nil
         default_config :custom_post_install_command, nil
         default_config :custom_post_play_command, nil
+        default_config :custom_pre_prepare_command, nil
+        default_config :custom_post_prepare_command, nil
         default_config :show_command_output, false
         default_config :ignore_ansible_cfg, false
 

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -270,6 +270,7 @@ module Kitchen
 
       def custom_post_prepare_command
         <<-PREPARE
+
           #{config[:custom_post_prepare_command]}
         PREPARE
       end

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -263,13 +263,14 @@ module Kitchen
 
       def custom_pre_prepare_command
         <<-PREPARE
-          #{config:[custom_pre_prepare_command]}
+
+          #{config[:custom_pre_prepare_command]}
         PREPARE
       end
 
       def custom_post_prepare_command
         <<-PREPARE
-          #{config:[custom_post_prepare_command]}
+          #{config[:custom_post_prepare_command]}
         PREPARE
       end
 

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -261,6 +261,18 @@ module Kitchen
         INSTALL
       end
 
+      def custom_pre_prepare_command
+        <<-PREPARE
+          #{config:[custom_pre_prepare_command]}
+        PREPARE
+      end
+
+      def custom_post_prepare_command
+        <<-PREPARE
+          #{config:[custom_post_prepare_command]}
+        PREPARE
+      end
+
       def init_command
         dirs = %w(modules roles group_vars host_vars)
                .map { |dir| File.join(config[:root_path], dir) }.join(' ')
@@ -374,7 +386,7 @@ module Kitchen
           ].join(' ')
         end
 
-        command = commands.join(' && ')
+        command = custom_pre_prepare_command + commands.join(' && ') + custom_post_prepare_command
         debug("*** COMMAND TO RUN:")
         debug(command)
         command

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -60,8 +60,10 @@ callback_plugins_path | callback_plugins | Ansible repo `callback_plugins` direc
 chef_bootstrap_url | `https://www.chef.io/chef/install.sh` | The Chef install
 custom_pre_install_command | nil | Custom shell command to be used at beginning of install stage. Can be multiline.
 custom_pre_play_command | nil | Custom shell command to be used before the ansible play stage. Can be multiline. See examples below.
+custom_pre_prepare_command | nil | Custom shell command to be used before the prepare_command is executed. Cann be multiline
 custom_post_install_command | nil | Custom shell command to be used at after the install stage. Can be multiline.
 custom_post_play_command | nil | Custom shell command to be used after the ansible play stage. Can be multiline. See examples below.
+custom_post_prepare_command | nil | Custom shell command to be used after the prepare_command is run. Can be multiline
 enable_yum_epel | false | Enable the `yum` EPEL repo
 env_vars | Hash.new | Hash to set environment variable to use with `ansible-playbook` command
 extra_vars | Hash.new | Hash to set the `extra_vars` passed to `ansible-playbook` command


### PR DESCRIPTION
In the Digital Products environment, all Github repos must remain private and accessible only via ssh. In order to run ansible-galaxy, test kitchen must load an ssh key to access github before ansible-galaxy is executed in the prepare_command block.  I've added the optional variables `custom_pre_prepare_command` and `custom_post_prepare_command` in the same pattern as `install_command` and `run_command`